### PR TITLE
Enhance Rollbar requests with more info

### DIFF
--- a/proc_wrapper/proc_wrapper.py
+++ b/proc_wrapper/proc_wrapper.py
@@ -1683,7 +1683,6 @@ class ProcWrapper:
             return False
 
         payload = {
-            "access_token": self.params.rollbar_access_token,
             "data": {
                 "environment": self.params.deployment or "Unknown",
                 "body": {
@@ -1707,15 +1706,19 @@ class ProcWrapper:
                     }
                 },
                 "level": level,
-                "server": {
-                    "host": self.hostname
-                    # Could put code version here
-                },
+                "timestamp": time.time(),
+                "code_version": self.params.task_version_signature,
+                "context": "proc_wrapper",
+                "server": {"host": self.hostname},
             },
         }
 
         request_body = json.dumps(payload).encode("utf-8")
-        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-Rollbar-Access-Token": self.params.rollbar_access_token,
+        }
         req = Request(
             "https://api.rollbar.com/api/1/item/",
             data=request_body,


### PR DESCRIPTION
1) code_version (with task version signature, e.g. git SHA)
2) timestamp (in case Rollbar requests are retried)
3) context (always set to "proc_wrapper")

Also move Rollbar auth token from request body to header, as request body is deprecated.